### PR TITLE
Add march=native option and target_compile_feature c++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ include(vcpkg) # Must set toolchain file before calling project()
 
 project(speller-benchmark VERSION 2.0 LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 # set(CPACK_PROJECT_NAME ${PROJECT_NAME})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,3 +9,22 @@ target_link_libraries(bench PRIVATE pthread)
 
 find_package(fmt CONFIG REQUIRED)
 target_link_libraries(bench PRIVATE fmt::fmt)
+
+set_target_properties(bench
+   PROPERTIES
+   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+target_compile_features(bench 
+PRIVATE 
+cxx_std_20
+cxx_decltype
+cxx_trailing_return_types)
+
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
+if(COMPILER_SUPPORTS_MARCH_NATIVE)
+   option(OPTIMIZE_FOR_NATIVE "Build with -march=native" ON)
+   if(OPTIMIZE_FOR_NATIVE)
+      target_compile_options(bench PRIVATE -march=native)
+   endif()
+endif()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,7 +34,7 @@
 #include <fmt/ranges.h>
 #include <fmt/std.h>
 
-#include <dirent.h>
+#include <unistd.h>
 #include <getopt.h>
 
 #define CS50_TEXTS "texts"
@@ -79,12 +79,12 @@ auto main(int argc, char *argv[]) -> int {
 	auto const count = file_count(text_files);
 	if (count == 0) exit(2);
 
-	std::vector<benchmark>   records{};
+	std::vector<benchmark>   records;
 	std::vector<std::thread> threads;
 	records.reserve(count);
 	threads.reserve(count);
 
-	for (auto const &txt : std::filesystem::directory_iterator{text_files}) {
+	for (auto const &txt : fs::directory_iterator{text_files}) {
 		assert(txt.is_regular_file() && "Non text file found in texts dir");
 		records.emplace_back(txt.path(), includeStaff);
 	}


### PR DESCRIPTION
Add a test for march=native and add an option to enable it. ON by default.

Removed CXX_STANDARD variable, and replaced it with target_compiler_features instead.