### PR TITLE
Hide irrelevant tests and simplify

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,12 @@ add_test(NAME single_thread
 add_test(NAME multi_thread
 	COMMAND bench
 	WORKING_DIRECTORY ${SPELLER_LOCATION})
-add_test(NAME single_thread_with_staff
-	COMMAND bench -1t
-	WORKING_DIRECTORY ${SPELLER_LOCATION})
-add_test(NAME multi_thread_with_staff
-	COMMAND bench -t
-	WORKING_DIRECTORY ${SPELLER_LOCATION})
+
+if(COMPARE_SPELLER50)
+	add_test(NAME single_thread_with_staff
+		COMMAND bench -1t
+		WORKING_DIRECTORY ${SPELLER_LOCATION})
+	add_test(NAME multi_thread_with_staff
+		COMMAND bench -t
+		WORKING_DIRECTORY ${SPELLER_LOCATION})
+endif()

--- a/src/benchmark.hpp
+++ b/src/benchmark.hpp
@@ -31,9 +31,9 @@ struct record {
 		return *this;
 	}
 
-	friend auto operator+(record lhs, record const &rhs) -> record {
-		lhs += rhs;
-		return lhs;
+	auto operator+(record other) const -> record {
+		other += *this;
+		return other;
 	}
 
 	template <typename Int>
@@ -70,9 +70,9 @@ class benchmark {
 		return *this;
 	}
 
-	friend auto operator+(benchmark lhs, benchmark const &rhs) -> benchmark {
-		lhs += rhs;
-		return lhs;
+	auto operator+(benchmark rhs) const -> benchmark {
+		rhs += *this;
+		return rhs;
 	}
 
 	template <typename Int = int>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,12 +126,11 @@ static void error_m(std::string_view message, int code) {
 
 static auto file_count(fs::path const &dir) noexcept ->
 		typename std::iterator_traits<fs::directory_iterator>::difference_type {
-	fs::directory_iterator i;
 	try {
-		i = fs::directory_iterator{dir};
+		return std::distance(fs::directory_iterator{dir},
+		                     fs::directory_iterator{});
 	} catch (const std::exception &e) {
 		fmt::print(stderr, "{}\n", e.what());
 		return 0;
 	}
-	return std::distance(i, fs::directory_iterator{});
 }


### PR DESCRIPTION
Hiding staff included tests if we can't run the staff version of speller.

Simplify some code.