### PR TITLE
Boost pipe

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,6 +6,7 @@
 	"dependencies": [
 		"fmt",
 		"range-v3",
+		"boost-process",
 		"catch2"
 	]
 }


### PR DESCRIPTION
Use boost::process to pipe output from speller rather than the old posix pipe with std::unique_ptr